### PR TITLE
Log error stack when cannot load or execute script.js file

### DIFF
--- a/src/core/CompiledTemplate.ts
+++ b/src/core/CompiledTemplate.ts
@@ -45,7 +45,7 @@ export class CompiledTemplate {
         resolve();
       } catch (e: any) {
         reject(
-          new BearTemplateError(`Could not load script file **${scriptPath}**`)
+          new BearTemplateError(`Could not load script file \`${scriptPath}\` \n\`\`\`${e}\n\`\`\``)
         );
       }
     });


### PR DESCRIPTION
Log full error stack message when workflow fails to load or execute the `script.js` file.
This helps tremendously when debugging.

BEFORE:

![image](https://user-images.githubusercontent.com/3105832/183254954-3846820c-e9a5-4d5e-8b8a-4d4f1cf9e1af.png)

AFTER:

![image](https://user-images.githubusercontent.com/3105832/183254956-b6855a02-3bbe-4939-aafb-7263ee2096bf.png)
